### PR TITLE
Make some fixes for PyTorch 1.0

### DIFF
--- a/data/moving_mnist.py
+++ b/data/moving_mnist.py
@@ -22,7 +22,7 @@ class MovingMNIST(object):
             train=train,
             download=True,
             transform=transforms.Compose(
-                [transforms.Scale(self.digit_size),
+                [transforms.Resize(self.digit_size),
                  transforms.ToTensor()]))
 
         self.N = len(self.data) 

--- a/utils.py
+++ b/utils.py
@@ -148,7 +148,8 @@ def make_image(tensor):
     if tensor.size(0) == 1:
         tensor = tensor.expand(3, tensor.size(1), tensor.size(2))
     # pdb.set_trace()
-    return scipy.misc.toimage(tensor.numpy(),
+    tensor = tensor.detach().numpy()
+    return scipy.misc.toimage(tensor,
                               high=255*tensor.max(),
                               channel_axis=0)
 


### PR DESCRIPTION
I made some small fixes for PyTorch 1.0. 

`transforms.Scale` has been deprecated and `transforms.Resize` should not be used.

And I was getting this bug:
```
Traceback (most recent call last):
  File "train_svg_lp.py", line 367, in <module>
    plot(x, epoch)
  File "train_svg_lp.py", line 251, in plot
    utils.save_tensors_image(fname, to_plot)
  File "/home/terence/repos/my_code/svg/utils.py", line 187, in save_tensors_image
    return save_image(filename, images)
  File "/home/terence/repos/my_code/svg/utils.py", line 182, in save_image
    img = make_image(tensor)
  File "/home/terence/repos/my_code/svg/utils.py", line 153, in make_image
    channel_axis=0)
  File "/home/terence/.local/lib/python3.6/site-packages/numpy/lib/utils.py", line 101, in newfu$
    return func(*args, **kwds)
  File "/home/terence/.local/lib/python3.6/site-packages/scipy/misc/pilutil.py", line 381, in to$
    bytedata = bytescale(data, high=high, low=low, cmin=cmin, cmax=cmax)
  File "/home/terence/.local/lib/python3.6/site-packages/numpy/lib/utils.py", line 101, in newfu$
    return func(*args, **kwds)
  File "/home/terence/.local/lib/python3.6/site-packages/scipy/misc/pilutil.py", line 105, in by$
    return (bytedata.clip(low, high) + 0.5).astype(uint8)
AttributeError: 'Tensor' object has no attribute 'astype'
```
When images were trying to be saved so I had to call `detach()` on the tensor before converting it to a numpy array. 